### PR TITLE
Adding ability to specify or skip frameworks on scans

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,16 @@
           "title": "Skip SSL cert verification",
           "markdownDescription": "Skip SSL certificate verification. Use this to bypass errors related to SSL certificates. Warning: this should only be used for testing purposes. Skipping certificate verification is dangerous as invalid and falsified certificates cannot be detected.",
           "type": "boolean"
+        },
+        "checkov.skipFrameworks": {
+          "title": "Skip Frameworks",
+          "markdownDescription": "Comma-separated list of frameworks to skip (e.g., 'arm, json, secrets, serverless'). \n This is useful if you do not need to scan or do not have the required license for a specific framework. \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "type": "string"
+        },
+        "checkov.frameworks": {
+          "title": "Frameworks",
+          "markdownDescription": "Comma-separated list of frameworks to scan (e.g., 'arm, json, secrets, serverless'). \n This is useful if you only want to scan specific frameworks. \n See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.",
+          "type": "string"
         }
       }
     }

--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -75,8 +75,8 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const noCertVerifyParam: string[] = noCertVerify ? ['--no-cert-verify'] : [];
         const skipCheckParam: string[] = skipChecks.length ? ['--skip-check', skipChecks.join(',')] : [];
         const externalChecksParams: string[] = externalChecksDir && checkovInstallationMethod !== 'docker' ? ['--external-checks-dir', externalChecksDir] : [];
-        const frameworkParams: string[] = frameworks ? ['--framework', frameworks.join(' ')] : [];
-        const skipFrameworkParams: string[] = skipFrameworks ? ['--skip-framework', skipFrameworks.join(' ')] : [];
+        const frameworkParams: string[] = frameworks ? frameworks.reduce((acc, framework) => [...acc, '--framework', framework], [] as string[] ) : [];
+        const skipFrameworkParams: string[] = skipFrameworks ? skipFrameworks.reduce((acc, framework) => [ ...acc, '--skip-framework', framework ], [] as string[] ) : [];
         const workingDir = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
             const repoIdParams = repoName ? ['--repo-id', repoName] : [];

--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -62,7 +62,7 @@ const cleanupStdout = (stdout: string) => stdout.replace(/.\[0m/g,''); // Clean 
 
 export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInstallation, extensionVersion: string, fileName: string, token: string, 
     certPath: string | undefined, useBcIds: boolean | undefined, debugLogs: boolean | undefined, noCertVerify: boolean | undefined, cancelToken: vscode.CancellationToken, 
-    configPath: string | undefined, checkovVersion: string,  prismaUrl: string | undefined, externalChecksDir: string | undefined): Promise<CheckovResponse> => {
+    configPath: string | undefined, checkovVersion: string,  prismaUrl: string | undefined, externalChecksDir: string | undefined, skipFrameworks: string[] | undefined, frameworks: string[] | undefined): Promise<CheckovResponse> => {
     return new Promise((resolve, reject) => {   
         const { checkovInstallationMethod, checkovPath } = checkovInstallation;
         const timestamp = Date.now();
@@ -75,11 +75,13 @@ export const runCheckovScan = (logger: Logger, checkovInstallation: CheckovInsta
         const noCertVerifyParam: string[] = noCertVerify ? ['--no-cert-verify'] : [];
         const skipCheckParam: string[] = skipChecks.length ? ['--skip-check', skipChecks.join(',')] : [];
         const externalChecksParams: string[] = externalChecksDir && checkovInstallationMethod !== 'docker' ? ['--external-checks-dir', externalChecksDir] : [];
+        const frameworkParams: string[] = frameworks ? ['--framework', frameworks.join(' ')] : [];
+        const skipFrameworkParams: string[] = skipFrameworks ? ['--skip-framework', skipFrameworks.join(' ')] : [];
         const workingDir = vscode.workspace.rootPath;
         getGitRepoName(logger, vscode.window.activeTextEditor?.document.fileName).then((repoName) => {
             const repoIdParams = repoName ? ['--repo-id', repoName] : [];
             const checkovArguments: string[] = [...dockerRunParams, ...certificateParams, ...bcIdParam, ...noCertVerifyParam, '-s', '--bc-api-key', token, 
-                ...repoIdParams, ...filePathParams, ...skipCheckParam, '-o', 'json', ...pipRunParams, ...externalChecksParams];
+                ...repoIdParams, ...filePathParams, ...skipCheckParam, '-o', 'json', ...pipRunParams, ...externalChecksParams, ...frameworkParams, ...skipFrameworkParams];
             logger.info('Running checkov:');
             logger.info(`${checkovPath} ${checkovArguments.map(argument => argument === token ? '****' : argument).join(' ')}`);
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -52,6 +52,18 @@ export const getNoCertVerify = (): boolean | undefined => {
     return noCertVerify;
 };
 
+export const getSkipFrameworks = (): string[] | undefined => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    const skipFrameworks = configuration.get<string>('skipFrameworks');
+    return skipFrameworks ? skipFrameworks.split(',') : undefined;
+};
+
+export const getFrameworks = (): string[] | undefined => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
+    const frameworks = configuration.get<string>('frameworks');
+    return frameworks ? frameworks.split(',') : undefined;
+};
+
 export const getCheckovVersion = async (logger: Logger): Promise<string> => {
 
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -55,14 +55,15 @@ export const getNoCertVerify = (): boolean | undefined => {
 export const getSkipFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const skipFrameworks = configuration.get<string>('skipFrameworks');
-    return skipFrameworks ? skipFrameworks.split(',') : undefined;
+    return skipFrameworks ? skipFrameworks.split(',').map(entry => entry.trim()) : undefined;
 };
 
 export const getFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov');
     const frameworks = configuration.get<string>('frameworks');
-    return frameworks ? frameworks.split(',') : undefined;
+    return frameworks ? frameworks.split(',').map(entry => entry.trim()) : undefined;
 };
+
 
 export const getCheckovVersion = async (logger: Logger): Promise<string> => {
 


### PR DESCRIPTION
# In This PR

- Added setting "Skip Frameworks" to take a comma separated list of frameworks to skip during scanning
- Added setting "Framworks" to take a comma separated list of frameworks to use during scanning

## Pictures/videos

#### Skip Frameworks 
![skip-frameworks](https://github.com/billyjbryant/checkov-vscode/assets/3013565/48a0c310-fdd2-4c10-a9d5-135b6336fb54)

#### Frameworks 
![frameworks](https://github.com/billyjbryant/checkov-vscode/assets/3013565/2eba2da5-95b2-4188-a051-2da14b5e52fd)

## Usage:

```bash
[info]: Running checkov: 
[info]: checkov --output-bc-ids -s --bc-api-key **** -f "/Users/billybryant/break-glass-amplify/amplify/backend/types/amplify-dependent-resources-ref.d.ts" --skip-check BC_LIC* -o json --skip-framework sca_package --skip-framework sca_image --skip-framework secrets 
[warn]: Checkov stderr: 2023-08-24 11:53:00,868 [MainThread  ] [ERROR]  There are no runners to run. This can happen if you specify a file type and a framework that are not compatible (e.g., `--file xyz.yaml --framework terraform`), or if you specify a framework with missing dependencies (e.g., helm or kustomize, which require those tools to be on your system). Running with LOG_LEVEL=DEBUG may provide more information.
 
[debug]: Checkov scan process exited with code 0 
[debug]: Checkov task output: 
[debug]: {
  "passed": 0,
  "failed": 0,
  "skipped": 0,
  "parsing_errors": 0,
  "resource_count": 0,
  "checkov_version": "2.4.0"
} 
[debug]: Saving results for file /Users/billybryant/break-glass-amplify/amplify/backend/types/amplify-dependent-resources-ref.d.ts (hash: ecebd6f7eca5ac8bc76d79b6f5960338) 
[debug]: Today: 1692860400000 
[debug]: Cache date: 1692860400000 
[debug]: Cache date (1692860400000) is not stale 
[debug]: First cache entry for file /Users/billybryant/break-glass-amplify/amplify/backend/types/amplify-dependent-resources-ref.d.ts 
[debug]: File /Users/billybryant/break-glass-amplify/amplify/backend/types/amplify-dependent-resources-ref.d.ts now has 1 saved results 
[info]: Cancellation token invoked, aborting checkov run. 
```

- [x] I've reviewed my own code
